### PR TITLE
Lynn15

### DIFF
--- a/linear_algebra/CMakeLists.txt
+++ b/linear_algebra/CMakeLists.txt
@@ -44,6 +44,9 @@ add_executable(test_integrate test_integrate.c)
 add_executable(test_openmp test_openmp.c)
 target_link_libraries(test_openmp OpenMP::OpenMP_C)
 
+add_executable(hello_openmp hello_openmp.c)
+target_link_libraries(hello_openmp OpenMP::OpenMP_C)
+
 add_test(test_vector_dot test_vector_dot)
 add_test(test_vector_add test_vector_add)
 add_test(test_matrix_vector_mul test_matrix_vector_mul)

--- a/linear_algebra/CMakeLists.txt
+++ b/linear_algebra/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(test_average_fortran test_average_fortran.F90)
 target_link_libraries(test_average_fortran OpenMP::OpenMP_Fortran)
 
 add_executable(test_integrate test_integrate.c)
+target_link_libraries(test_integrate OpenMP::OpenMP_C)
 
 add_executable(test_openmp test_openmp.c)
 target_link_libraries(test_openmp OpenMP::OpenMP_C)

--- a/linear_algebra/test_integrate.c
+++ b/linear_algebra/test_integrate.c
@@ -22,7 +22,7 @@ main(int argc, char **argv)
     double x0 = i * dx;
     double x1 = (i+1) * dx;
     double val = .5 * (f(x0) + f(x1)) * dx;
-#pragma omp critical
+#pragma omp atomic
     sum += val;
   }
   double tend = Wtime();

--- a/linear_algebra/test_integrate.c
+++ b/linear_algebra/test_integrate.c
@@ -17,16 +17,13 @@ main(int argc, char **argv)
 
   double tbeg = Wtime();
   double sum = 0.;
-#pragma omp parallel
-  {
-	double local_sum = 0.;
-#pragma omp for
-    for (int i = 0; i < N; i++) {
-      double x0 = i * dx;
-      double x1 = (i+1) * dx;
-      local_sum += .5 * (f(x0) + f(x1)) * dx;;
-    }
-    sum += local_sum;
+#pragma omp parallel for
+  for (int i = 0; i < N; i++) {
+    double x0 = i * dx;
+    double x1 = (i+1) * dx;
+    double val = .5 * (f(x0) + f(x1)) * dx;
+#pragma omp critical
+    sum += val;
   }
   double tend = Wtime();
 

--- a/linear_algebra/test_integrate.c
+++ b/linear_algebra/test_integrate.c
@@ -1,6 +1,7 @@
-
+#include "omp.h"
 #include <stdio.h>
 #include <math.h>
+#include "linear_algebra.h"
 
 static double
 f(double x)
@@ -14,13 +15,22 @@ main(int argc, char **argv)
   const int N = 1000;
   double dx = 1. / N;
 
+  double tbeg = Wtime();
   double sum = 0.;
-  for (int i = 0; i < N; i++) {
-    double x0 = i * dx;
-    double x1 = (i+1) * dx;
-    sum += .5 * (f(x0) + f(x1)) * dx;
+#pragma omp parallel
+  {
+	double local_sum = 0.;
+#pragma omp for
+    for (int i = 0; i < N; i++) {
+      double x0 = i * dx;
+      double x1 = (i+1) * dx;
+      local_sum += .5 * (f(x0) + f(x1)) * dx;;
+    }
+    sum += local_sum;
   }
-  printf("sum = %g\n", sum);
+  double tend = Wtime();
+
+  printf("The sum is %f and the time is %f\n", sum, tend - tbeg);
 
   return 0;
 }


### PR DESCRIPTION
Starting submission from Race condition as per assignment page:

After fixing the code, the program runs very fast, but the answer is not correct. Here is an example output:

```
The sum is 0.462974 and the time is 0.013475
```
The answer should be about 0.78

After updating the integration again using the critical key word I consistently get 0.785389 as the correct answer. The performance is very fast, as well. On average 0.01 seconds. Here is some output:

```
The sum is 0.785389 and the time is 0.012422
[jhl1002@agate build]$ ./test_integrate
The sum is 0.785389 and the time is 0.011821
[jhl1002@agate build]$ ./test_integrate
The sum is 0.785389 and the time is 0.010843
[jhl1002@agate build]$ ./test_integrate
The sum is 0.785389 and the time is 0.011682
[jhl1002@agate build]$ ./test_integrate
The sum is 0.785389 and the time is 0.016428
```

Critical will protect sum+= to guarantee there is no race conditions. Unless I misunderstood the critical term, it seems correct. 

Atomic has little to no difference than critical in our example.

The reduction will drop the time by about 1/3 to 1/2. Much more efficient, and has the correct answer as we had done in class!

 

